### PR TITLE
fix: glassmorphism blur

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -132,7 +132,6 @@
 .glass {
   background: rgba(255, 255, 255, 0.72);
   backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(0, 0, 0, 0.06);
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.04);
 }
@@ -391,7 +390,6 @@ body.mobile-open .mobile-nav-panel { display: block; }
 .dark .glass {
   background: rgba(14, 21, 40, 0.78);
   backdrop-filter: blur(20px);
-  -webkit-backdrop-filter: blur(20px);
   border: 1px solid rgba(148, 163, 184, 0.08);
   box-shadow:
     0 1px 3px rgba(0, 0, 0, 0.4),
@@ -447,7 +445,6 @@ body.mobile-open .mobile-nav-panel { display: block; }
   /* Light mode style */
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(12px);
-  -webkit-backdrop-filter: blur(12px);
   box-shadow:
     0 2px 8px rgba(0, 0, 0, 0.08),
     0 0 0 1px rgba(0, 0, 0, 0.04);


### PR DESCRIPTION
Lightning CSS (via Tailwind v4) autoprefixes backdrop-filter from browserslist. When both prefixed and unprefixed variants are authored manually, its deduper collapses them to whichever appears last — the unprefixed declaration was being dropped, leaving Firefox with no blur and the navbar/banner rendering as a nearly-transparent white tint on the near-white background.

Remove the redundant -webkit-backdrop-filter lines and let Lightning emit both properties automatically. Verified compiled output now ships both.