### PR TITLE
fix: apply theme changes instantly

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -512,11 +512,3 @@ body.mobile-open .mobile-nav-panel { display: block; }
     0 0 0 1px rgba(100, 140, 200, 0.3),
     0 0 24px rgba(59, 130, 246, 0.15);
 }
-
-/* ── Dark mode transition for smooth toggle ── */
-html.transitioning,
-html.transitioning *,
-html.transitioning *::before,
-html.transitioning *::after {
-  transition: background-color 0.3s ease, border-color 0.3s ease, color 0.15s ease, box-shadow 0.3s ease !important;
-}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -90,7 +90,7 @@ export default async function RootLayout({
       <head>
         <script
           dangerouslySetInnerHTML={{
-            __html: `try{if(localStorage.getItem('championslab-theme')==='dark')document.documentElement.classList.add('dark')}catch(e){}
+            __html: `try{var t=localStorage.getItem('championslab-theme');document.documentElement.style.colorScheme=t==='dark'?'dark':'light';if(t==='dark')document.documentElement.classList.add('dark')}catch(e){}
 try{var l=localStorage.getItem('championslab-lang');if(l){document.cookie='cl-lang='+l+';path=/;max-age=31536000;SameSite=Lax'}}catch(e){}`,
           }}
         />

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -1,29 +1,41 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useSyncExternalStore } from "react";
 import { motion, AnimatePresence } from "@/lib/motion";
 import { Sun, Moon } from "lucide-react";
 
-export function ThemeToggle() {
-  const [dark, setDark] = useState(false);
-  const [mounted, setMounted] = useState(false);
+const THEME_CHANGE_EVENT = "theme-change";
 
-  useEffect(() => {
-    setDark(document.documentElement.classList.contains("dark"));
-    setMounted(true);
-  }, []);
+const getThemeSnapshot = () =>
+  typeof document !== "undefined" &&
+  document.documentElement.classList.contains("dark");
+
+const getServerThemeSnapshot = () => false;
+
+const subscribeToTheme = (onStoreChange: () => void) => {
+  window.addEventListener(THEME_CHANGE_EVENT, onStoreChange);
+  window.addEventListener("storage", onStoreChange);
+
+  return () => {
+    window.removeEventListener(THEME_CHANGE_EVENT, onStoreChange);
+    window.removeEventListener("storage", onStoreChange);
+  };
+};
+
+export function ThemeToggle() {
+  const dark = useSyncExternalStore(
+    subscribeToTheme,
+    getThemeSnapshot,
+    getServerThemeSnapshot,
+  );
 
   const toggle = () => {
-    const next = !dark;
-    setDark(next);
-    // Add transition class for smooth color change
-    document.documentElement.classList.add("transitioning");
+    const next = !document.documentElement.classList.contains("dark");
     document.documentElement.classList.toggle("dark", next);
+    document.documentElement.style.colorScheme = next ? "dark" : "light";
     localStorage.setItem("championslab-theme", next ? "dark" : "light");
-    setTimeout(() => document.documentElement.classList.remove("transitioning"), 350);
+    window.dispatchEvent(new Event(THEME_CHANGE_EVENT));
   };
-
-  if (!mounted) return null;
 
   return (
     <motion.button


### PR DESCRIPTION
## Summary

Fixes the theme-toggle lag where parts of the UI stayed in the previous light/dark theme briefly after switching modes.

## Changes

- Removed the global `html.transitioning *` CSS transition that forced theme colors across the whole document to animate.
- Updated `ThemeToggle` to apply `.dark`, `color-scheme`, and localStorage updates synchronously.
- Replaced mount-time state syncing with `useSyncExternalStore`.
- Updated the pre-hydration theme script to set `color-scheme` before first paint.

Fixes: #30 